### PR TITLE
Tests for Validation, Field, and Input

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,9 @@
       "./test/test_helper.js"
     ],
     "exclude": [
-      "docs",
-      "storybook",
       "HOC",
-      "components"
+      "components",
+      "styleguide"
     ],
     "include": [
       "src/**/*.{js,jsx}"

--- a/src/HOC/handler/index.jsx
+++ b/src/HOC/handler/index.jsx
@@ -15,10 +15,10 @@ export default (WrappedComponent) => {
 
     static childContextTypes = {
       ...(WrappedComponent.childContextTypes || {}),
-      nfGetValue: PropTypes.func.isRequired,
-      nfOnChange: PropTypes.func.isRequired,
-      nfFullName: PropTypes.func.isRequired,
-      nfFormIndex: PropTypes.number.isRequired,
+      ffGetValue: PropTypes.func.isRequired,
+      ffOnChange: PropTypes.func.isRequired,
+      ffFullName: PropTypes.func.isRequired,
+      ffFormIndex: PropTypes.number.isRequired,
       formSubscription: PropTypes.objectOf(PropTypes.func).isRequired,
     };
 
@@ -40,10 +40,10 @@ export default (WrappedComponent) => {
         : {};
       return {
         ...superChildContext,
-        nfGetValue: this.getValue,
-        nfOnChange: this.onChange,
-        nfFullName: () => ([]),
-        nfFormIndex: this.formIndex,
+        ffGetValue: this.getValue,
+        ffOnChange: this.onChange,
+        ffFullName: () => ([]),
+        ffFormIndex: this.formIndex,
         formSubscription: {
           subscribe: callback => this.subscriptions.push(callback),
           unsubscribe: (callback) => {

--- a/src/HOC/submit/index.jsx
+++ b/src/HOC/submit/index.jsx
@@ -11,8 +11,8 @@ export default (WrappedComponent) => {
 
     static childContextTypes = {
       ...(WrappedComponent.childContextTypes || {}),
-      nfIsLoading: PropTypes.func.isRequired,
-      nfCanSubmit: PropTypes.func.isRequired,
+      ffIsLoading: PropTypes.func.isRequired,
+      ffCanSubmit: PropTypes.func.isRequired,
     }
 
     getChildContext() {
@@ -21,8 +21,8 @@ export default (WrappedComponent) => {
         : {};
       return {
         ...superChildContext,
-        nfIsLoading: () => this.isLoading(),
-        nfCanSubmit: () => this.canSubmit(),
+        ffIsLoading: () => this.isLoading(),
+        ffCanSubmit: () => this.canSubmit(),
       };
     }
 

--- a/src/HOC/valid/index.jsx
+++ b/src/HOC/valid/index.jsx
@@ -11,7 +11,7 @@ export default (WrappedComponent) => {
 
     static childContextTypes = {
       ...(WrappedComponent.childContextTypes || {}),
-      nfUpdateValidation: PropTypes.func.isRequired,
+      ffUpdateValidation: PropTypes.func.isRequired,
     }
 
     constructor(props, context) {
@@ -29,7 +29,7 @@ export default (WrappedComponent) => {
         : {};
       return {
         ...superChildContext,
-        nfUpdateValidation: this.updateValidation,
+        ffUpdateValidation: this.updateValidation,
       };
     }
 

--- a/src/components/Field/index.jsx
+++ b/src/components/Field/index.jsx
@@ -28,7 +28,7 @@ export default class Field extends ValueSubscriber {
 
   static contextTypes = {
     ...ValueSubscriber.contextTypes,
-    nfFormIndex: PropTypes.number.isRequired,
+    ffFormIndex: PropTypes.number.isRequired,
   }
 
   getOtherProps() {
@@ -50,7 +50,7 @@ export default class Field extends ValueSubscriber {
       onChange: this.boundOnChange,
       value: this.getValue(),
       'data-name': this.getName().join('.'),
-      id: `${this.context.nfFormIndex}.${this.getName().join('.')}`,
+      id: `${this.context.ffFormIndex}.${this.getName().join('.')}`,
     };
     if (typeof otherProps.value !== 'undefined') {
       fieldProps['data-value'] = fieldProps.value;

--- a/src/components/Label/index.jsx
+++ b/src/components/Label/index.jsx
@@ -29,8 +29,8 @@ export default class Label extends React.PureComponent {
   };
 
   static contextTypes = {
-    nfFullName: PropTypes.func.isRequired,
-    nfFormIndex: PropTypes.number.isRequired,
+    ffFullName: PropTypes.func.isRequired,
+    ffFormIndex: PropTypes.number.isRequired,
   };
 
   render() {
@@ -43,7 +43,7 @@ export default class Label extends React.PureComponent {
     return (
       <Component
         {...restProps}
-        htmlFor={[this.context.nfFormIndex].concat(this.context.nfFullName(), htmlFor).join('.')}
+        htmlFor={[this.context.ffFormIndex].concat(this.context.ffFullName(), htmlFor).join('.')}
       >
         {children}
       </Component>

--- a/src/components/Validation/index.jsx
+++ b/src/components/Validation/index.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 
 import ValueSubscriber from '../ValueSubscriber/';
 
-const runValidationRules = (rules, value, invalidate) => {
+export const runValidationRules = (rules, value, invalidate) => {
   if (typeof rules === 'object') {
     if (Array.isArray(rules)) {
       rules.forEach(rule => runValidationRules(rule, value, invalidate));
     } else {
-      Object.entries(rules).forEach(([key, rule]) => {
+      Object.keys(rules).forEach((key) => {
         runValidationRules(
-          rule,
+          rules[key],
           value[key],
           (error, nestedName = []) => invalidate(error, [key].concat(nestedName)),
         );
@@ -74,6 +74,11 @@ export default class Validation extends ValueSubscriber {
     this.runValidation();
   }
 
+  componentWillUnmount() {
+    super.componentWillUnmount();
+    this.context.nfUpdateValidation(this.state.validationResult, []);
+  }
+
   // TODO: If the rules prop changes, revalidate
 
   runValidation() {
@@ -114,7 +119,7 @@ export default class Validation extends ValueSubscriber {
     return (
       <ul>
         {/* eslint-disable-next-line react/no-array-index-key */}
-        {this.state.validationResult.map((v, i) => <li key={i}>{v}</li>)}
+        {this.state.validationResult.map((v, i) => <li key={i}>{v[1]}</li>)}
       </ul>
     );
   }

--- a/src/components/Validation/index.jsx
+++ b/src/components/Validation/index.jsx
@@ -53,7 +53,7 @@ export default class Validation extends ValueSubscriber {
 
   static contextTypes = {
     ...ValueSubscriber.contextTypes,
-    nfUpdateValidation: PropTypes.func.isRequired,
+    ffUpdateValidation: PropTypes.func.isRequired,
   };
 
   constructor(props, context) {
@@ -76,7 +76,7 @@ export default class Validation extends ValueSubscriber {
 
   componentWillUnmount() {
     super.componentWillUnmount();
-    this.context.nfUpdateValidation(this.state.validationResult, []);
+    this.context.ffUpdateValidation(this.state.validationResult, []);
   }
 
   // TODO: If the rules prop changes, revalidate
@@ -107,7 +107,7 @@ export default class Validation extends ValueSubscriber {
 
     const oldResult = this.state.validationResult;
     this.setState({ validationResult: result });
-    this.context.nfUpdateValidation(oldResult, result);
+    this.context.ffUpdateValidation(oldResult, result);
   }
 
   /**

--- a/src/components/ValueSubscriber/index.jsx
+++ b/src/components/ValueSubscriber/index.jsx
@@ -51,14 +51,14 @@ export default class ValueSubscriber extends Subscriber {
 
   static contextTypes = {
     ...Subscriber.contextTypes,
-    nfGetValue: PropTypes.func.isRequired,
-    nfOnChange: PropTypes.func.isRequired,
-    nfFullName: PropTypes.func.isRequired,
+    ffGetValue: PropTypes.func.isRequired,
+    ffOnChange: PropTypes.func.isRequired,
+    ffFullName: PropTypes.func.isRequired,
   };
 
   static childContextTypes = {
-    nfGetValue: PropTypes.func.isRequired,
-    nfFullName: PropTypes.func.isRequired,
+    ffGetValue: PropTypes.func.isRequired,
+    ffFullName: PropTypes.func.isRequired,
   };
 
   constructor(props, context) {
@@ -68,8 +68,8 @@ export default class ValueSubscriber extends Subscriber {
 
   getChildContext() {
     return {
-      nfGetValue: () => this.getValue(),
-      nfFullName: this.getName,
+      ffGetValue: () => this.getValue(),
+      ffFullName: this.getName,
     };
   }
 
@@ -98,7 +98,7 @@ export default class ValueSubscriber extends Subscriber {
     // Check to make sure we aren't changing the value's type
     invariantTypesMatch(this.getName().concat(name), objectPath.get(this.getValue(), name), value);
 
-    this.context.nfOnChange(fakeChangeEvent(this.getName().concat(name), value));
+    this.context.ffOnChange(fakeChangeEvent(this.getName().concat(name), value));
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -120,7 +120,7 @@ export default class ValueSubscriber extends Subscriber {
    */
   getValue() {
     const hasName = (typeof this.props.name !== 'undefined' && this.props.name !== '');
-    const value = this.context.nfGetValue();
+    const value = this.context.ffGetValue();
     invariant(
       typeof value !== 'undefined' && (!hasName || typeof value[this.props.name] !== 'undefined'),
       `"${this.getName().join('.')}" must have a value. Please check the handler's getDefaults() method.`,
@@ -134,7 +134,7 @@ export default class ValueSubscriber extends Subscriber {
    * @public
    */
   getName = () => {
-    const parentName = this.context.nfFullName();
+    const parentName = this.context.ffFullName();
     if (typeof this.props.name === 'undefined' || this.props.name === '') { return parentName; }
     return parentName.concat(this.props.name);
   };

--- a/src/components/ValueTransformer/index.jsx
+++ b/src/components/ValueTransformer/index.jsx
@@ -21,13 +21,13 @@ export default class ValueTransformer extends ValueSubscriber {
 
   static childContextTypes = {
     ...ValueSubscriber.childContextTypes,
-    nfOnChange: PropTypes.func.isRequired,
+    ffOnChange: PropTypes.func.isRequired,
   }
 
   getChildContext() {
     return {
       ...super.getChildContext(),
-      nfOnChange: e => this.onChange(e),
+      ffOnChange: e => this.onChange(e),
     };
   }
 

--- a/src/components/WithSubmit/index.jsx
+++ b/src/components/WithSubmit/index.jsx
@@ -15,8 +15,8 @@ export default class WithSubmit extends Subscriber {
 
   static contextTypes = {
     ...Subscriber.contextTypes,
-    nfIsLoading: PropTypes.func.isRequired,
-    nfCanSubmit: PropTypes.func.isRequired,
+    ffIsLoading: PropTypes.func.isRequired,
+    ffCanSubmit: PropTypes.func.isRequired,
   };
 
   constructor(props, context) {
@@ -27,21 +27,21 @@ export default class WithSubmit extends Subscriber {
 
   componentDidMount() {
     super.componentDidMount();
-    this.oldIsLoading = this.context.nfIsLoading();
-    this.oldCanSubmit = this.context.nfCanSubmit();
+    this.oldIsLoading = this.context.ffIsLoading();
+    this.oldCanSubmit = this.context.ffCanSubmit();
   }
 
   shouldComponentUpdate(nextProps, nextState, nextContext) {
     if (super.shouldComponentUpdate(nextProps, nextState, nextContext)) { return true; }
     let shouldUpdate = false;
 
-    const newIsLoading = this.context.nfIsLoading();
+    const newIsLoading = this.context.ffIsLoading();
     if (newIsLoading !== this.oldIsLoading) {
       this.oldIsLoading = newIsLoading;
       shouldUpdate = true;
     }
 
-    const newCanSubmit = this.context.nfCanSubmit();
+    const newCanSubmit = this.context.ffCanSubmit();
     if (newCanSubmit !== this.oldCanSubmit) {
       this.oldCanSubmit = newCanSubmit;
       shouldUpdate = true;
@@ -52,8 +52,8 @@ export default class WithSubmit extends Subscriber {
 
   render() {
     return this.props.children({
-      isLoading: this.context.nfIsLoading(),
-      canSubmit: this.context.nfCanSubmit(),
+      isLoading: this.context.ffIsLoading(),
+      canSubmit: this.context.ffCanSubmit(),
     }) || null;
   }
 }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,26 +1,6 @@
 export const getDisplayName =
   component => component.displayName || component.name || 'Component';
 
-// Returns a function, that, as long as it continues to be invoked, will not
-// be triggered. The function will be called after it stops being called for
-// N milliseconds. If `immediate` is passed, trigger the function on the
-// leading edge, instead of the trailing.
-export const debounce = (func, wait, immediate) => {
-  let timeout;
-  return () => {
-    const context = this;
-    const args = arguments;
-    const later = () => {
-      timeout = null;
-      if (!immediate) func.apply(context, args);
-    };
-    const callNow = immediate && !timeout;
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-    if (callNow) func.apply(context, args);
-  };
-};
-
 export const noop = /* istanbul ignore next */ () => {};
 
 export const fakeChangeEvent = (name, value) => ({

--- a/test/HOC/handler.jsx
+++ b/test/HOC/handler.jsx
@@ -39,17 +39,17 @@ describe('HOC/handler', () => {
 
     let expectedVal = defaultValues;
     expect(wrapper.state().values).to.deep.equal(defaultValues);
-    expect(instance.getChildContext().nfGetValue()).to.deep.equal(defaultValues);
+    expect(instance.getChildContext().ffGetValue()).to.deep.equal(defaultValues);
 
     expectedVal = { ...expectedVal, a: false };
     instance.onChange(({ target: { name: 'a', value: false } }));
     expect(wrapper.state().values).to.deep.equal(expectedVal);
-    expect(instance.getChildContext().nfGetValue()).to.deep.equal(expectedVal);
+    expect(instance.getChildContext().ffGetValue()).to.deep.equal(expectedVal);
 
     instance.onChange(({ target: { name: ['d', 'd1'], value: 'updated' } }));
     expectedVal = { ...expectedVal, d: { d1: 'updated' } };
     expect(wrapper.state().values).to.deep.equal(expectedVal);
-    expect(instance.getChildContext().nfGetValue()).to.deep.equal(expectedVal);
+    expect(instance.getChildContext().ffGetValue()).to.deep.equal(expectedVal);
   });
 
   it('creates a form tag automatically', () => {
@@ -102,6 +102,6 @@ describe('HOC/handler', () => {
   it('sets default name', () => {
     const DefaultHandler = handler(TestWithDefaults);
     const context = shallow(<DefaultHandler />).instance().getChildContext();
-    expect(context.nfFullName()).to.deep.equal([]);
+    expect(context.ffFullName()).to.deep.equal([]);
   });
 });

--- a/test/HOC/submit.jsx
+++ b/test/HOC/submit.jsx
@@ -28,22 +28,22 @@ describe('HOC/submit', () => {
   it('supports isLoading() and canSubmit()', () => {
     const DefaultHandler = submit(handler(Test));
     const childContext = shallow(<DefaultHandler />).instance().getChildContext();
-    expect(childContext.nfCanSubmit()).to.equal(true);
-    expect(childContext.nfIsLoading()).to.equal(false);
+    expect(childContext.ffCanSubmit()).to.equal(true);
+    expect(childContext.ffIsLoading()).to.equal(false);
 
     const SubmitHandler = submit(handler(class extends Test {
       canSubmit() { return false; }
     }));
     const childContext2 = shallow(<SubmitHandler />).instance().getChildContext();
-    expect(childContext2.nfCanSubmit()).to.equal(false);
-    expect(childContext2.nfIsLoading()).to.equal(false);
+    expect(childContext2.ffCanSubmit()).to.equal(false);
+    expect(childContext2.ffIsLoading()).to.equal(false);
 
     const LoadingHandler = submit(handler(class extends Test {
       isLoading() { return true; }
     }));
     const childContext3 = shallow(<LoadingHandler />).instance().getChildContext();
-    expect(childContext3.nfCanSubmit()).to.equal(false);
-    expect(childContext3.nfIsLoading()).to.equal(true);
+    expect(childContext3.ffCanSubmit()).to.equal(false);
+    expect(childContext3.ffIsLoading()).to.equal(true);
   });
 
   it('adds onSubmit to the formProps()', () => {

--- a/test/HOC/valid.jsx
+++ b/test/HOC/valid.jsx
@@ -39,35 +39,35 @@ describe('HOC/valid', () => {
   it('adds and removes validation arrays when called, and blocks sumbit accordingly', () => {
     const TestHandler = valid(handler(Test));
     const component = shallow(<TestHandler />).instance();
-    const { nfUpdateValidation } = component.getChildContext();
+    const { ffUpdateValidation } = component.getChildContext();
 
     expect(component.state.validationResults.length).to.equal(0);
 
     // Handles initial mount
-    nfUpdateValidation(undefined, []);
+    ffUpdateValidation(undefined, []);
     expect(component.state.validationResults.length).to.equal(0);
 
-    nfUpdateValidation([], []);
+    ffUpdateValidation([], []);
     expect(component.state.validationResults.length).to.equal(0);
 
     const validationResult = ['Error'];
-    nfUpdateValidation([], validationResult);
+    ffUpdateValidation([], validationResult);
     expect(component.state.validationResults.length).to.equal(1);
     // Shouldn't be able to submit the form with validation errors
     expect(component.canSubmit()).to.equal(false);
 
     // Test other components triggering their own validation
-    nfUpdateValidation([], []);
+    ffUpdateValidation([], []);
     expect(component.state.validationResults.length).to.equal(1);
     const otherValidationResult = ['Another error'];
-    nfUpdateValidation([], otherValidationResult);
+    ffUpdateValidation([], otherValidationResult);
     expect(component.state.validationResults.length).to.equal(2);
     expect(component.canSubmit()).to.equal(false);
 
     // Begin clearing errors
-    nfUpdateValidation(validationResult, []);
+    ffUpdateValidation(validationResult, []);
     expect(component.state.validationResults.length).to.equal(1);
-    nfUpdateValidation(otherValidationResult, []);
+    ffUpdateValidation(otherValidationResult, []);
     expect(component.state.validationResults.length).to.equal(0);
     expect(component.canSubmit()).to.equal(true);
   });

--- a/test/components/Field.jsx
+++ b/test/components/Field.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+import Field from 'react-freeform/components/Field';
+
+// Tests for components that this extends or uses
+import './Input';
+
+const values = {
+  a: true,
+  b: null,
+  c: ['1', '2'],
+  d: {
+    d1: 'nested',
+  },
+};
+
+const noop = () => {};
+const context = {
+  ffGetValue: () => values,
+  ffFullName: () => ([]),
+  ffFormIndex: 1,
+  ffOnChange: noop,
+  formSubscription: { subscribe: noop, unsubscribe: noop },
+};
+
+describe('components/Field', () => {
+  it('should filter out internal props from the passthrough props', () => {
+    const wrapper = shallow(<Field name="a" component="input" onChange={noop} a="1" />, { context });
+    expect(wrapper.instance().getOtherProps()).to.deep.equal({ a: '1', children: null });
+  });
+
+  it('should support overriding the input component', () => {
+    expect(mount(<Field />, { context }).find('input').length).to.equal(1);
+
+    const TestInput = () => <h1>Test</h1>;
+    const wrapper = shallow(<Field component={TestInput} />, { context });
+    expect(wrapper.find('input').length).to.equal(0);
+    expect(wrapper.find(TestInput).length).to.equal(1);
+  });
+
+  it('should pass data-value with the true value, if it receives value as a prop', () => {
+    const wrapper = mount(<Field value="test" name="a" />, { context });
+    const input = wrapper.find('input');
+    expect(input.props()).to.have.property('value', 'test');
+    expect(input.props()).to.have.property('data-value', true);
+  });
+
+  it('should pass data-name as a string of the entire form path', () => {
+    expect(mount(<Field value="test" name="a" />, { context }).find('input').props())
+      .to.have.property('data-name', 'a');
+    expect(mount(
+      <Field value="test" name="d1" />,
+      { context: { ...context, ffFullName: () => (['d']), ffGetValue: () => ({ d1: 'test' }) } },
+    ).find('input').props()).to.have.property('data-name', 'd.d1');
+  });
+
+  it('should pass id as a string of the entire form path with a form identifier', () => {
+    expect(mount(<Field value="test" name="a" />, { context }).find('input').props())
+      .to.have.property('id', '1.a');
+    expect(mount(
+      <Field value="test" name="d1" />,
+      { context: { ...context, ffFullName: () => (['d']), ffGetValue: () => ({ d1: 'test' }) } },
+    ).find('input').props()).to.have.property('id', '1.d.d1');
+  });
+
+  it('should pass a working onChange into the input', () => {
+    const ffOnChange = sinon.spy();
+    const input = mount(<Field name="a" />, { context: { ...context, ffOnChange } }).find('input');
+    input.simulate('change', { target: { name: '', value: false } });
+    expect(ffOnChange.calledOnce).to.equal(true);
+    expect(ffOnChange.args[0][0].target).to.deep.equal({ name: ['a'], value: false });
+  });
+});

--- a/test/components/Input.jsx
+++ b/test/components/Input.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import Input from 'react-freeform/components/Input/';
+
+const noop = () => {};
+describe('components/Input', () => {
+  it('should render an input with basic props', () => {
+    const onChange = sinon.spy((e) => {
+      expect(e.target.value).to.equal('changed');
+      expect(e.target.name).to.equal('');
+    });
+    const wrapper = mount(<Input value="test" onChange={onChange} data-name="" />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    expect(input.instance().value).to.equal('test');
+    input.simulate('change', { target: { name: '', value: 'changed' } });
+    expect(onChange.calledOnce).to.equal(true);
+  });
+
+  it('should pass additional props through', () => {
+    const wrapper = mount(<Input value="" onChange={noop} data-name="" data-myprop="exists" />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    expect(input.props()).to.have.property('data-myprop', 'exists');
+  });
+
+  it('should render a checkbox', () => {
+    const onChange = sinon.spy((e) => {
+      expect(e.target.value).to.equal(false);
+      expect(e.target.name).to.equal('');
+    });
+    const wrapper = mount(<Input value onChange={onChange} data-name="" type="checkbox" />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    expect(input.instance().value).to.equal('on');
+    expect(input.instance().checked).to.equal(true);
+    input.simulate('change', { target: { name: '', checked: false } });
+    expect(onChange.calledOnce).to.equal(true);
+  });
+
+  it('should render a radio', () => {
+    const onChange = sinon.spy(value => expect(value).to.equal('b'));
+    const wrapper = mount(<Input name="test" value="a" data-value="a" onChange={onChange} data-name="radioName" type="radio" />);
+    const input = wrapper.find('input');
+    expect(input.length).to.equal(1);
+    // Value is 'a', but the checked flag is set if it matches data-value
+    expect(input.instance().value).to.equal('a');
+    expect(input.instance().checked).to.equal(true);
+    // It should use data-name, since that should be fairly unique in the form
+    expect(input.props()).to.have.property('name', 'radioName');
+    // Emit an event with a name, and the onChange handler should just pass the
+    // value on. Name is stripped intentionally
+    input.simulate('change', { target: { name: 'radioName', value: 'b' } });
+    expect(onChange.calledOnce).to.equal(true);
+
+    // Try rendering a radio that isn't currently selected
+    const wrapper2 = mount(<Input name="test" value="a" data-value="b" onChange={noop} data-name="radioName" type="radio" />);
+    const input2 = wrapper2.find('input');
+    expect(input2.length).to.equal(1);
+    // Value is 'a', but the checked flag is set if it matches data-value
+    expect(input2.instance().value).to.equal('a');
+    expect(input2.instance().checked).to.equal(false);
+  });
+});

--- a/test/components/Validation.jsx
+++ b/test/components/Validation.jsx
@@ -19,10 +19,10 @@ const values = {
 
 const noop = () => {};
 const context = {
-  nfOnChange: noop,
-  nfUpdateValidation: noop,
-  nfGetValue: () => values,
-  nfFullName: () => ([]),
+  ffOnChange: noop,
+  ffUpdateValidation: noop,
+  ffGetValue: () => values,
+  ffFullName: () => ([]),
   formSubscription: { subscribe: noop, unsubscribe: noop },
 };
 
@@ -90,12 +90,12 @@ describe('components/runValidationRules', () => {
 
 describe('components/Validation', () => {
   it('should run validation when mounting', () => {
-    const nfUpdateValidation = sinon.spy();
+    const ffUpdateValidation = sinon.spy();
     const rule = sinon.spy((_, invalidate) => invalidate('test'));
-    shallow(<Validation rules={rule} />, { context: { ...context, nfUpdateValidation } });
+    shallow(<Validation rules={rule} />, { context: { ...context, ffUpdateValidation } });
     expect(rule.calledOnce).to.equal(true);
-    expect(nfUpdateValidation.calledOnce).to.equal(true);
-    expect(nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+    expect(ffUpdateValidation.calledOnce).to.equal(true);
+    expect(ffUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
   });
 
   it('should run validation after an update has been triggered', () => {
@@ -104,7 +104,7 @@ describe('components/Validation', () => {
     const rule = sinon.spy((_, invalidate) => (rule.calledTwice ? invalidate('test') : false));
     const componentContext = {
       ...context,
-      nfUpdateValidation: sinon.spy(),
+      ffUpdateValidation: sinon.spy(),
       formSubscription: {
         subscribe: (func) => { triggerUpdate = func; },
         unsubscribe: noop,
@@ -112,12 +112,12 @@ describe('components/Validation', () => {
     };
     shallow(<Validation rules={rule} />, { context: componentContext });
     expect(rule.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(false);
 
     triggerUpdate();
     expect(rule.calledTwice).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
   });
 
   it('should only send updates if validation results change', () => {
@@ -127,7 +127,7 @@ describe('components/Validation', () => {
     const rule = sinon.spy((_, invalidate) => (error ? invalidate(error) : false));
     const componentContext = {
       ...context,
-      nfUpdateValidation: sinon.spy(),
+      ffUpdateValidation: sinon.spy(),
       formSubscription: {
         subscribe: (func) => { triggerUpdate = func; },
         unsubscribe: noop,
@@ -136,34 +136,34 @@ describe('components/Validation', () => {
     // No errors on first render
     shallow(<Validation rules={rule} />, { context: componentContext });
     expect(rule.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(false);
 
     // No errors on second render
     triggerUpdate();
     expect(rule.calledTwice).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(false);
 
     // Errors on third render
     error = 'Error';
     triggerUpdate();
     expect(rule.calledThrice).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'Error']])).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledWith([], [[[], 'Error']])).to.equal(true);
   });
 
   it('should remove validation when unmounting', () => {
     const rule = sinon.spy((_, invalidate) => invalidate('test'));
-    const componentContext = { ...context, nfUpdateValidation: sinon.spy() };
+    const componentContext = { ...context, ffUpdateValidation: sinon.spy() };
     const wrapper = shallow(<Validation rules={rule} />, { context: componentContext });
     expect(rule.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
 
     wrapper.unmount();
 
     expect(rule.calledTwice).to.equal(false);
-    expect(componentContext.nfUpdateValidation.calledTwice).to.equal(true);
-    expect(componentContext.nfUpdateValidation.calledWith([[[], 'test']], []))
+    expect(componentContext.ffUpdateValidation.calledTwice).to.equal(true);
+    expect(componentContext.ffUpdateValidation.calledWith([[[], 'test']], []))
       .to.equal(true, 'Validation was not cleared before unmount');
   });
 
@@ -185,7 +185,7 @@ describe('components/Validation', () => {
     rules = makeRule('change message');
     wrapper.setProps({ rules });
     // TODO: Triggering the update and render here instead of from the
-    // nfUpdateValidation context, and it needs to be cleaned up
+    // ffUpdateValidation context, and it needs to be cleaned up
     triggerUpdate();
     wrapper.update();
     expect(wrapper.find('li').length).to.equal(1);
@@ -195,7 +195,7 @@ describe('components/Validation', () => {
     rules = [rules, makeRule('error')];
     wrapper.setProps({ rules });
     // TODO: Triggering the update and render here instead of from the
-    // nfUpdateValidation context, and it needs to be cleaned up
+    // ffUpdateValidation context, and it needs to be cleaned up
     triggerUpdate();
     wrapper.update();
     expect(wrapper.find('li').length).to.equal(2);

--- a/test/components/Validation.jsx
+++ b/test/components/Validation.jsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+
+import Validation, { runValidationRules } from 'react-freeform/components/Validation';
+
+// Tests for components that this extends or uses
+import './ValueSubscriber';
+
+const values = {
+  a: true,
+  b: null,
+  c: ['1', '2'],
+  d: {
+    d1: 'nested',
+  },
+};
+
+const noop = () => {};
+const context = {
+  nfOnChange: noop,
+  nfUpdateValidation: noop,
+  nfGetValue: () => values,
+  nfFullName: () => ([]),
+  formSubscription: { subscribe: noop, unsubscribe: noop },
+};
+
+describe('components/runValidationRules', () => {
+  it('should support a validation function', () => {
+    const rule = sinon.spy();
+    runValidationRules(rule, {}, noop);
+    expect(rule.calledOnce).to.equal(true);
+    expect(rule.calledWith({}, noop)).to.equal(true);
+  });
+
+  it('should support an array of validation functions', () => {
+    const rule1 = sinon.spy();
+    const rule2 = sinon.spy();
+    runValidationRules([rule1, rule2], {}, noop);
+    expect(rule1.calledOnce).to.equal(true);
+    expect(rule1.calledWith({}, noop)).to.equal(true);
+    expect(rule2.calledOnce).to.equal(true);
+    expect(rule2.calledWith({}, noop)).to.equal(true);
+  });
+
+  it('should support an object of validation functions, nesting the value by key', () => {
+    const rules = {
+      a: sinon.spy(),
+      c: sinon.spy((_, invalidate) => invalidate('Test')),
+    };
+    const invalidateSpy = sinon.spy(noop);
+
+    runValidationRules(rules, values, invalidateSpy);
+    expect(rules.a.calledOnce).to.equal(true);
+    expect(rules.a.args[0][0]).to.equal(values.a);
+
+    expect(rules.c.calledOnce).to.equal(true);
+    expect(rules.c.args[0][0]).to.equal(values.c);
+
+    expect(invalidateSpy.calledOnce).to.equal(true);
+    expect(invalidateSpy.calledWith('Test', ['c'])).to.equal(true);
+  });
+
+  it('should support arrays and objects nested in objects', () => {
+    const rules = {
+      c: [
+        sinon.spy((_, invalidate) => invalidate('Test')),
+        sinon.spy(),
+      ],
+      d: {
+        d1: sinon.spy((_, invalidate) => invalidate('Test')),
+      },
+    };
+    const invalidateSpy = sinon.spy(noop);
+
+    runValidationRules(rules, values, invalidateSpy);
+    expect(rules.c[0].calledOnce).to.equal(true);
+    expect(rules.c[0].args[0][0]).to.equal(values.c);
+    expect(invalidateSpy.calledWith('Test', ['c'])).to.equal(true);
+
+    expect(rules.c[1].calledOnce).to.equal(true);
+    expect(rules.c[1].args[0][0]).to.equal(values.c);
+
+    expect(rules.d.d1.calledOnce).to.equal(true);
+    expect(rules.d.d1.args[0][0]).to.equal(values.d.d1);
+    expect(invalidateSpy.calledWith('Test', ['d', 'd1'])).to.equal(true);
+  });
+});
+
+describe('components/Validation', () => {
+  it('should run validation when mounting', () => {
+    const nfUpdateValidation = sinon.spy();
+    const rule = sinon.spy((_, invalidate) => invalidate('test'));
+    shallow(<Validation rules={rule} />, { context: { ...context, nfUpdateValidation } });
+    expect(rule.calledOnce).to.equal(true);
+    expect(nfUpdateValidation.calledOnce).to.equal(true);
+    expect(nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+  });
+
+  it('should run validation after an update has been triggered', () => {
+    let triggerUpdate;
+    // Only invalidate on the second call
+    const rule = sinon.spy((_, invalidate) => (rule.calledTwice ? invalidate('test') : false));
+    const componentContext = {
+      ...context,
+      nfUpdateValidation: sinon.spy(),
+      formSubscription: {
+        subscribe: (func) => { triggerUpdate = func; },
+        unsubscribe: noop,
+      },
+    };
+    shallow(<Validation rules={rule} />, { context: componentContext });
+    expect(rule.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+
+    triggerUpdate();
+    expect(rule.calledTwice).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+  });
+
+  it('should only send updates if validation results change', () => {
+    let triggerUpdate;
+    let error = false;
+    // Only invalidate on the second call
+    const rule = sinon.spy((_, invalidate) => (error ? invalidate(error) : false));
+    const componentContext = {
+      ...context,
+      nfUpdateValidation: sinon.spy(),
+      formSubscription: {
+        subscribe: (func) => { triggerUpdate = func; },
+        unsubscribe: noop,
+      },
+    };
+    // No errors on first render
+    shallow(<Validation rules={rule} />, { context: componentContext });
+    expect(rule.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+
+    // No errors on second render
+    triggerUpdate();
+    expect(rule.calledTwice).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(false);
+
+    // Errors on third render
+    error = 'Error';
+    triggerUpdate();
+    expect(rule.calledThrice).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'Error']])).to.equal(true);
+  });
+
+  it('should remove validation when unmounting', () => {
+    const rule = sinon.spy((_, invalidate) => invalidate('test'));
+    const componentContext = { ...context, nfUpdateValidation: sinon.spy() };
+    const wrapper = shallow(<Validation rules={rule} />, { context: componentContext });
+    expect(rule.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledOnce).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledWith([], [[[], 'test']])).to.equal(true);
+
+    wrapper.unmount();
+
+    expect(rule.calledTwice).to.equal(false);
+    expect(componentContext.nfUpdateValidation.calledTwice).to.equal(true);
+    expect(componentContext.nfUpdateValidation.calledWith([[[], 'test']], []))
+      .to.equal(true, 'Validation was not cleared before unmount');
+  });
+
+  it('should render a list of errors', () => {
+    let triggerUpdate;
+    const componentContext = {
+      ...context,
+      formSubscription: {
+        subscribe: (func) => { triggerUpdate = func; },
+        unsubscribe: noop,
+      },
+    };
+
+    const makeRule = error => (_, invalidate) => invalidate(error);
+    let rules = makeRule('test');
+    const wrapper = mount(<Validation rules={rules} />, { context: componentContext });
+    expect(wrapper.find('li').length).to.equal(1);
+
+    rules = makeRule('change message');
+    wrapper.setProps({ rules });
+    // TODO: Triggering the update and render here instead of from the
+    // nfUpdateValidation context, and it needs to be cleaned up
+    triggerUpdate();
+    wrapper.update();
+    expect(wrapper.find('li').length).to.equal(1);
+    expect(wrapper.find('li').text()).to.equal('change message');
+
+    // Set the rules to two rules
+    rules = [rules, makeRule('error')];
+    wrapper.setProps({ rules });
+    // TODO: Triggering the update and render here instead of from the
+    // nfUpdateValidation context, and it needs to be cleaned up
+    triggerUpdate();
+    wrapper.update();
+    expect(wrapper.find('li').length).to.equal(2);
+  });
+
+  it('should support displaying errors before or after children', () => {
+    const rules = (_, invalidate) => invalidate('Error');
+    expect(shallow(<Validation rules={rules}>Child</Validation>, { context }).text())
+      .to.equal('ChildError');
+
+    expect(shallow(<Validation rules={rules} displayBeforeChildren>Child</Validation>, { context }).text())
+      .to.equal('ErrorChild');
+  });
+});

--- a/test/components/ValueSubscriber.jsx
+++ b/test/components/ValueSubscriber.jsx
@@ -19,9 +19,9 @@ const values = {
 
 const noop = () => {};
 const context = {
-  nfOnChange: noop,
-  nfGetValue: () => values,
-  nfFullName: () => ([]),
+  ffOnChange: noop,
+  ffGetValue: () => values,
+  ffFullName: () => ([]),
   formSubscription: { subscribe: noop, unsubscribe: noop },
 };
 
@@ -29,20 +29,20 @@ describe('components/ValueSubscriber', () => {
   it('provides access to the form values without a name', () => {
     const wrapper = shallow(<ValueSubscriber />, { context });
     const component = wrapper.instance();
-    expect(component.getChildContext().nfGetValue()).to.equal(values);
+    expect(component.getChildContext().ffGetValue()).to.equal(values);
   });
 
   it('uses the name for nesting values and onChange events', () => {
     const testChange = (name, value, onChangeArg, event) => {
-      const nfOnChange = sinon.spy();
-      const wrapper = shallow(<ValueSubscriber name={name} />, { context: { ...context, nfOnChange } });
+      const ffOnChange = sinon.spy();
+      const wrapper = shallow(<ValueSubscriber name={name} />, { context: { ...context, ffOnChange } });
       const component = wrapper.instance();
       const childContext = component.getChildContext();
-      expect(childContext.nfGetValue()).to.equal(value);
+      expect(childContext.ffGetValue()).to.equal(value);
 
       component.onChange(onChangeArg);
-      expect(nfOnChange.calledOnce).to.equal(true);
-      expect(nfOnChange.args[0][0].target).to.deep.equal(event);
+      expect(ffOnChange.calledOnce).to.equal(true);
+      expect(ffOnChange.args[0][0].target).to.deep.equal(event);
     };
 
     testChange('a', values.a, { target: { name: '', value: false } }, { name: ['a'], value: false });
@@ -55,22 +55,22 @@ describe('components/ValueSubscriber', () => {
   });
 
   it('handles numbers for accessing array values', () => {
-    const nfOnChange = sinon.spy();
+    const ffOnChange = sinon.spy();
     const wrapper = shallow(<ValueSubscriber name="0" />, {
-      context: { ...context, nfOnChange, nfGetValue: () => values.c },
+      context: { ...context, ffOnChange, ffGetValue: () => values.c },
     });
     const component = wrapper.instance();
     expect(component.getValue()).to.equal(values.c[0]);
 
     component.onChange('replaced');
-    expect(nfOnChange.calledOnce).to.equal(true);
-    expect(nfOnChange.args[0][0].target).to.deep.equal({ name: ['0'], value: 'replaced' });
+    expect(ffOnChange.calledOnce).to.equal(true);
+    expect(ffOnChange.args[0][0].target).to.deep.equal({ name: ['0'], value: 'replaced' });
   });
 
   it('only rerenders when the value changes, or props/state change', () => {
     let testValue = values;
     const wrapper = mount(<ValueSubscriber />, {
-      context: { ...context, nfGetValue: () => testValue },
+      context: { ...context, ffGetValue: () => testValue },
     });
     const shouldUpdateSpy = sinon.spy(wrapper.instance(), 'shouldComponentUpdate');
 
@@ -100,11 +100,11 @@ describe('components/ValueSubscriber', () => {
       .to.throw('"thisKeyIsMissing" must have a value. Please check the handler\'s getDefaults() method.');
   });
 
-  it('nests context.nfFullName()', () => {
+  it('nests context.ffFullName()', () => {
     const getFullName = (name, childName, val = values) => shallow(
       <ValueSubscriber name={childName} />,
-      { context: { ...context, nfFullName: () => [].concat(name), nfGetValue: () => val } },
-    ).instance().getChildContext().nfFullName();
+      { context: { ...context, ffFullName: () => [].concat(name), ffGetValue: () => val } },
+    ).instance().getChildContext().ffFullName();
 
     expect(getFullName('d')).to.deep.equal(['d']);
     expect(getFullName('d', 'd1', { d1: true })).to.deep.equal(['d', 'd1']);
@@ -113,7 +113,7 @@ describe('components/ValueSubscriber', () => {
 
   it('enforces onChange not altering value types', () => {
     const changeType = (oldVal, newVal, name) =>
-      shallow(<ValueSubscriber />, { context: { ...context, nfGetValue: () => oldVal } })
+      shallow(<ValueSubscriber />, { context: { ...context, ffGetValue: () => oldVal } })
         .instance()
         .onChange({ target: { name, value: newVal } });
 

--- a/test/components/WithValue.jsx
+++ b/test/components/WithValue.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';

--- a/test/components/WithValue.jsx
+++ b/test/components/WithValue.jsx
@@ -20,9 +20,9 @@ const values = {
 
 const noop = () => {};
 const context = {
-  nfGetValue: () => values,
-  nfFullName: () => ([]),
-  nfOnChange: noop,
+  ffGetValue: () => values,
+  ffFullName: () => ([]),
+  ffOnChange: noop,
   formSubscription: { subscribe: noop, unsubscribe: noop },
 };
 
@@ -44,15 +44,15 @@ describe('components/WithValue', () => {
 
   it('should pass a working onChange into the render function', () => {
     const render = sinon.spy(() => null);
-    const nfOnChange = sinon.spy();
+    const ffOnChange = sinon.spy();
 
-    shallow(<WithValue>{render}</WithValue>, { context: { ...context, nfOnChange } });
+    shallow(<WithValue>{render}</WithValue>, { context: { ...context, ffOnChange } });
     expect(render.args[0][1]).to.be.an('object');
     expect(render.args[0][1].onChange).to.be.a('function');
 
     const { onChange } = render.args[0][1];
     onChange({ a: false });
-    expect(nfOnChange.calledOnce).to.equal(true);
-    expect(nfOnChange.args[0][0].target).to.deep.equal({ name: [], value: { a: false } });
+    expect(ffOnChange.calledOnce).to.equal(true);
+    expect(ffOnChange.args[0][0].target).to.deep.equal({ name: [], value: { a: false } });
   });
 });


### PR DESCRIPTION
Changes to source code

* Validation errors are removed when the `<Validation>` component is unmounted
* Renamed `nf` prefix on context to `ff`
* Removed `debounce` from utilities, since it isn't used